### PR TITLE
Updating demo to demonstrate usage of ports.

### DIFF
--- a/demo/src/API.elm
+++ b/demo/src/API.elm
@@ -1,4 +1,4 @@
-module API exposing (..)
+port module API exposing (..)
 
 import Pipelines.Quote as Quote
 import Route exposing (..)
@@ -71,6 +71,9 @@ router conn =
             internalError (TextBody "bugs, bugs, bugs")
                 |> toResponder responsePort
 
+        ( GET, Number ) ->
+            Conn.pipeline |> loop number
+
         _ ->
             -- use this form of toResponder when you need to access the conn
             toResponder responsePort <|
@@ -80,10 +83,34 @@ router conn =
                         |> textBody ("Nothing at: " ++ conn.req.path)
 
 
+number : Msg -> Conn -> ( Conn, Cmd Msg )
+number msg conn =
+    case msg of
+        Endpoint ->
+            ( conn, getRandom () )
+
+        RandomNumber val ->
+            conn
+                |> textBody (toString val)
+                |> statusCode 200
+                |> send responsePort
+
+        _ ->
+            conn
+                |> unexpectedMsg msg
+                |> send responsePort
+
+
 
 -- SUBSCRIPTIONS
 
 
+port getRandom : () -> Cmd msg
+
+
+port random : (Float -> msg) -> Sub msg
+
+
 subscriptions : Conn -> Sub Msg
 subscriptions _ =
-    Sub.none
+    random RandomNumber

--- a/demo/src/Pipelines/Quote.elm
+++ b/demo/src/Pipelines/Quote.elm
@@ -123,6 +123,11 @@ loadQuotes lang msg conn =
                         |> internalError (err |> toString |> TextBody)
                         |> send responsePort
 
+        _ ->
+            conn
+                |> unexpectedMsg msg
+                |> send responsePort
+
 
 respondWithQuotes : Msg -> Conn -> ( Conn, Cmd Msg )
 respondWithQuotes msg conn =

--- a/demo/src/Route.elm
+++ b/demo/src/Route.elm
@@ -7,6 +7,7 @@ type Route
     = Home
     | Quote Lang
     | Buggy
+    | Number
     | NotFound
 
 
@@ -21,6 +22,7 @@ route =
         [ map Home top
         , map Quote (s "quote" </> lang)
         , map Buggy (s "buggy")
+        , map Number (s "number")
         ]
 
 

--- a/demo/src/Types.elm
+++ b/demo/src/Types.elm
@@ -52,6 +52,7 @@ to the program as `endpoint` (see above).
 type Msg
     = Endpoint
     | QuoteResult (Result Http.Error Quote)
+    | RandomNumber Float
 
 
 

--- a/demo/src/api.js
+++ b/demo/src/api.js
@@ -29,6 +29,14 @@ module.exports.handler = elmServerless.httpApi({
   // Your elm app is the handler
   handler: elm.API,
 
+  bindPorts: (app) => {
+    app.ports.getRandom.subscribe(() => {
+      const val = Math.random();
+      console.log('val', val);
+      app.ports.random.send(val);
+    });
+  },
+
   // Config is a record type that you define.
   // You will also provide a JSON decoder for this.
   // It should be deployment data that is constant, perhaps loaded from


### PR DESCRIPTION
There is an unresolved issue. This doesn’t actually work because the port is sending the message directly to the serverless api, and it doesn’t have the information needed to forward the msg into the correct plug.